### PR TITLE
Upgrade from ga.js to Universal Analytics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+npm-debug.log

--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# ep_google_analytics
+
+Add Google Analytics to Etherpad Lite
+
+**IMPORTANT**: Add the following to your settings.json file:
+```
+"ep_googleanalytics": {
+  "gaCode": "UA-1234567-8"
+}
+```

--- a/index.js
+++ b/index.js
@@ -9,18 +9,16 @@ if(settings.ep_googleanalytics){ // Setup testing else poop out
 
 exports.eejsBlock_scripts = function (hook_name, args, cb) {
   if(gaCode){
-    var gaString = "<script type='text/javascript'>var _gaq = _gaq || [];_gaq.push(['_setAccount', '"+gaCode+"']);_gaq.push(['_trackPageview']);(function() {var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);})();</script>";
+    var gaString = eejs.require('ep_googleanalytics/templates/analytics.ejs', {gaCode: gaCode});
   }
   else{ // gaCode isn't set
     var gaString = "<script>alert('ep_googleanalytics.gaCode not set in settings.json, insert it in /admin/settings')</script>";
   }
 
 /* Leaving this in here for sanity */
-//  gaString += "<script type='text/javascript'>function sendGA(this){_gaq.push(['_trackEvent', this, 'Click', document.domain]);alert('sending to GA');}/* Google Analytics error catching */window.onerror = function(message, file, lineNumber) {_gaq.push(['_trackEvent','error',file + ':' + lineNumber,message + '']);};alert('test');$('div').bind('click', sendGA(this));$('ul').bind('click', sendGA(this));$('li').bind('click', alert('fu');sendGA(this));";
+//  gaString += "<script type='text/javascript'>function sendGA(this){ga('send','event', this, 'Click', document.domain]);alert('sending to GA');}/* Google Analytics error catching */window.onerror = function(message, file, lineNumber) {ga('send','event','error',file + ':' + lineNumber,message + '']);};alert('test');$('div').bind('click', sendGA(this));$('ul').bind('click', sendGA(this));$('li').bind('click', alert('fu');sendGA(this));";
 //  gaString += "<script type='text/javascript'>$('a').bind('click', alert('wut'));</script>";
 
   args.content = args.content + gaString; // add Google Analytics to the contents
   return cb();
 }
-
-

--- a/package.json
+++ b/package.json
@@ -7,7 +7,12 @@
     "email": "john@mclear.co.uk",
     "url": "http://mclear.co.uk"
   },
-  "contributors": [],
+  "contributors": [
+    {
+      "name": "Luiza Pagliari",
+      "email": "lpagliari@gmail.com"
+    }
+  ],
   "dependencies": {},
   "repository" : {
     "type" : "git",
@@ -18,5 +23,4 @@
     "shasum": "a6fa43074f12b65e975752151f08e170f573df21"
   },
   "_from": "ep_googleanalytics",
-  "readme": "ERROR: No README.md file found!"
 }

--- a/package.json
+++ b/package.json
@@ -22,5 +22,5 @@
   "dist": {
     "shasum": "a6fa43074f12b65e975752151f08e170f573df21"
   },
-  "_from": "ep_googleanalytics",
+  "_from": "ep_googleanalytics"
 }

--- a/templates/analytics.ejs
+++ b/templates/analytics.ejs
@@ -1,0 +1,8 @@
+<script>
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+ga('create', '<%= gaCode %>', 'auto');
+ga('send', 'pageview');
+</script>


### PR DESCRIPTION
As per https://support.google.com/analytics/answer/4457764?hl=en, ga.js is being deprecated, so we need to migrate to Universal Analytics.